### PR TITLE
Add sentence accumulator

### DIFF
--- a/src/llm/output/actions_parser.py
+++ b/src/llm/output/actions_parser.py
@@ -24,3 +24,6 @@ class actions_parser(output_parser):
                     # if action.is_interrupting:
                     #     settings.stop_generation = True
         return cut_content, last_content
+    
+    def get_cut_indicators(self) -> list[str]:
+        return [":"]

--- a/src/llm/output/change_character_parser.py
+++ b/src/llm/output/change_character_parser.py
@@ -54,3 +54,6 @@ class change_character_parser(output_parser):
 
     def modify_sentence_content(self, cut_content: sentence_content, last_content: sentence_content | None, settings: sentence_generation_settings) -> tuple[sentence_content | None, sentence_content | None]:
         return cut_content, last_content
+    
+    def get_cut_indicators(self) -> list[str]:
+        return [":"]

--- a/src/llm/output/narration_parser.py
+++ b/src/llm/output/narration_parser.py
@@ -28,6 +28,9 @@ class narration_parser(output_parser):
         else:
             self.__start_speech_reg = never_match_anything_regex
             self.__end_speech_reg = never_match_anything_regex
+    
+    def get_cut_indicators(self) -> list[str]:
+        return self.__narration_start_chars + self.__narration_end_chars + self.__speech_start_chars + self.__speech_end_chars
 
     def cut_sentence(self, output: str, current_settings: sentence_generation_settings) -> tuple[sentence_content | None, str]:
         output = output.lstrip()

--- a/src/llm/output/output_parser.py
+++ b/src/llm/output/output_parser.py
@@ -70,3 +70,6 @@ class output_parser(ABC):
     @abstractmethod
     def modify_sentence_content(self, cut_content: sentence_content, last_content: sentence_content | None, settings: sentence_generation_settings) -> tuple[sentence_content | None, sentence_content | None]:
         return cut_content, last_content
+    
+    def get_cut_indicators(self) -> list[str]:
+        return []

--- a/src/llm/output/sentence_accumulator.py
+++ b/src/llm/output/sentence_accumulator.py
@@ -1,0 +1,43 @@
+import re
+
+
+class sentence_accumulator:
+    """Accumulates the token-wise output of an LLM into raw sentences.
+    """
+    def __init__(self, cut_indicators: list[str]) -> None:
+        self.__cut_indicators = cut_indicators
+        self.__unprocessed_llm_output: str = ""
+        base_regex_def = "^.*?[{sentence_end_chars}]+"
+        self.__sentence_end_reg = re.compile(base_regex_def.format(sentence_end_chars = "\\" + "\\".join(cut_indicators)))
+        self.__unparseable: str = ""
+        self.__prepared_match: str = ""
+    
+    def has_next_sentence(self) -> bool:
+        if len(self.__prepared_match) > 0:
+            return True
+        
+        match = self.__sentence_end_reg.match(self.__unprocessed_llm_output)
+        if not match:
+            return False
+        else:
+            self.__prepared_match = match.group()
+            self.__unprocessed_llm_output = self.__unprocessed_llm_output.removeprefix(self.__prepared_match)
+            return True
+    
+    def get_next_sentence(self) -> str:
+        result = self.__unparseable + self.__prepared_match
+        self.__unparseable = ""
+        self.__prepared_match = ""
+        return result
+    
+    def accumulate(self, llm_output: str):
+        llm_output = llm_output.replace('\r\n', ' ')
+        llm_output = llm_output.replace('\n', ' ')
+        self.__unprocessed_llm_output += llm_output
+    
+    def refuse(self, refused_text: str):
+        self.__unparseable = refused_text
+    
+
+
+    

--- a/src/llm/output/sentence_end_parser.py
+++ b/src/llm/output/sentence_end_parser.py
@@ -23,3 +23,6 @@ class sentence_end_parser(output_parser):
 
     def modify_sentence_content(self, cut_content: sentence_content, last_content: sentence_content | None, settings: sentence_generation_settings) -> tuple[sentence_content | None, sentence_content | None]:
         return cut_content, last_content
+    
+    def get_cut_indicators(self) -> list[str]:
+        return self.__end_of_sentence_chars


### PR DESCRIPTION
Adds a sentence accumulator that adds a guard in front of the parsing_chain. LLM output that is too short to be processed correctly will not be handed to the chain until something is accumulated that can be parsed. LLM output that is too long gets pre cut into correct chunks before handed to the chain.